### PR TITLE
Quickly show the root cause of testcontainers startup failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,11 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    testLogging {
+        // Pipe the forked test JVM's stdout/stderr (logback output, Testcontainers'
+        // compose logs) into the Gradle console; otherwise it only lands in the HTML report.
+        showStandardStreams = true
+    }
 }
 
 avro {
@@ -66,8 +71,6 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 configurations.all {
-    exclude group: 'ch.qos.logback', module: 'logback-classic'
-
     resolutionStrategy.capabilitiesResolution.withCapability('org.lz4:lz4-java') {
         select('at.yawk.lz4:lz4-java:1.11.0')
     }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/2181'"]
       interval: 5s
       timeout: 5s
-      retries: 20
+      retries: 3
 
   broker:
     image: confluentinc/cp-kafka:latest
@@ -51,7 +51,7 @@ services:
       test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/9093'"]
       interval: 5s
       timeout: 5s
-      retries: 20
+      retries: 3
 
   kafka-init:
     image: confluentinc/cp-kafka:latest
@@ -67,7 +67,7 @@ services:
       test: ["CMD-SHELL", "kafka-topics --bootstrap-server broker:9093 --command-config /tmp/client.properties --topic new-orders --describe > /dev/null 2>&1 && kafka-topics --bootstrap-server broker:9093 --command-config /tmp/client.properties --topic wip-orders --describe > /dev/null 2>&1"]
       interval: 5s
       timeout: 5s
-      retries: 20
+      retries: 3
 
   schema-registry:
     image: confluentinc/cp-schema-registry:latest
@@ -99,7 +99,7 @@ services:
       test: ["CMD-SHELL", "curl -f -u admin:admin-secret -s http://localhost:8085/subjects > /dev/null"]
       interval: 5s
       timeout: 5s
-      retries: 20
+      retries: 3
 
   register-schemas:
     image: curlimages/curl:8.20.0
@@ -123,7 +123,7 @@ services:
       test: ["CMD-SHELL", "curl -f -u admin:admin-secret -s http://schema-registry:8085/subjects/new-orders-value/versions/latest > /dev/null && curl -f -u admin:admin-secret -s http://schema-registry:8085/subjects/wip-orders-value/versions/latest > /dev/null"]
       interval: 5s
       timeout: 5s
-      retries: 20
+      retries: 3
 
   order-service:
     profiles:
@@ -147,7 +147,7 @@ services:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8080/actuator/health > /dev/null"]
       interval: 5s
       timeout: 5s
-      retries: 20
+      retries: 3
 
   specmatic-test:
     profiles:

--- a/src/test/kotlin/com/example/order/ContractTestUsingTestContainer.kt
+++ b/src/test/kotlin/com/example/order/ContractTestUsingTestContainer.kt
@@ -1,14 +1,19 @@
 package com.example.order
 
+import io.specmatic.testcontainers.UnhealthyContainerHealthcheckLogger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.slf4j.LoggerFactory
 import org.springframework.boot.test.context.SpringBootTest
+import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.BindMode
 import org.testcontainers.containers.ComposeContainer
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.images.PullPolicy
@@ -19,10 +24,15 @@ import java.time.Duration
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ContractTestUsingTestContainer {
     companion object {
+        private val logger = LoggerFactory.getLogger(ContractTestUsingTestContainer::class.java)
         private val DOCKER_COMPOSE_FILE = File("docker-compose.yaml")
         private const val REGISTER_SCHEMAS_SERVICE = "register-schemas"
         private const val SCHEMA_REGISTERED_REGEX = ".*(?i)schemas registered.*"
         private const val AVRO_APP_NETWORK = "avro-app-network"
+
+        @JvmField
+        @RegisterExtension
+        val unhealthyContainerHealthchecks = UnhealthyContainerHealthcheckLogger(dockerClient = DockerClientFactory.instance().client())
     }
 
     private val schemaRegistry = schemaRegistry()
@@ -75,7 +85,7 @@ class ContractTestUsingTestContainer {
                     .withStartupTimeout(Duration.ofMinutes(3))
             )
             .withNetworkMode(AVRO_APP_NETWORK)
-            .withLogConsumer { print(it.utf8String) }
+            .withLogConsumer(Slf4jLogConsumer(logger))
     }
 
     @Test

--- a/src/test/kotlin/io/specmatic/testcontainers/UnhealthyContainerHealthcheckLogger.kt
+++ b/src/test/kotlin/io/specmatic/testcontainers/UnhealthyContainerHealthcheckLogger.kt
@@ -1,0 +1,90 @@
+package io.specmatic.testcontainers
+
+import com.github.dockerjava.api.DockerClient
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.InvocationInterceptor
+import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext
+import org.slf4j.LoggerFactory
+import java.lang.reflect.Method
+
+class UnhealthyContainerHealthcheckLogger(val dockerClient: DockerClient) : InvocationInterceptor {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun interceptBeforeAllMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    override fun interceptBeforeEachMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    override fun interceptTestMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    override fun interceptTestTemplateMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    override fun interceptAfterEachMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    override fun interceptAfterAllMethod(
+        invocation: Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext,
+    ) {
+        invocation.dumpHealthchecksOnFailure()
+    }
+
+    private fun <T> Invocation<T>.dumpHealthchecksOnFailure(): T {
+        try {
+            return proceed()
+        } catch (e: Throwable) {
+            logUnhealthyContainerHealthchecks().forEach(e::addSuppressed)
+            throw e
+        }
+    }
+
+    private fun logUnhealthyContainerHealthchecks(): List<Throwable> {
+        val unhealthy = dockerClient.listContainersCmd()
+            .withShowAll(true)
+            .withFilter("health", listOf("unhealthy"))
+            .exec()
+        return unhealthy.map { container ->
+            val name = container.names.firstOrNull()?.trimStart('/') ?: container.id
+            val healthLog = dockerClient.inspectContainerCmd(container.id).exec()
+                .state.health?.log.orEmpty()
+                .joinToString("\n") { "[exit=${it.exitCodeLong}] ${it.output?.trim()}" }
+            val message = "Healthcheck output for unhealthy container '$name':\n$healthLog"
+            logger.error(message)
+            UnhealthyContainerException(message)
+        }
+    }
+
+    private class UnhealthyContainerException(message: String) : Exception(message) {
+        override fun fillInStackTrace(): Throwable = this
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Quickly show the root cause of testcontainers startup failure. These changes are generic and can be applied to all other sample projects that use testcontainers. UnhealthyContainerHealthcheckLogger is a reusable component.

Now the underlying cause will be highlighted. Creating a stacked PR that fixes the underlying issue for this repo.