### PR TITLE
Fix schema-registry healthcheck and surface its root cause in CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,9 @@ dependencies {
 test {
     useJUnitPlatform()
     testLogging {
-        // Pipe the forked test JVM's stdout/stderr (logback output, Testcontainers'
-        // compose logs) into the Gradle console; otherwise it only lands in the HTML report.
         showStandardStreams = true
+        exceptionFormat = 'full'
+        showStackTraces = true
     }
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -96,7 +96,7 @@ services:
       - ./docker-config/schema-registry-jaas.conf:/etc/schema-registry/schema-registry-jaas.conf
       - ./docker-config/password.properties:/etc/schema-registry/password.properties
     healthcheck:
-      test: ["CMD-SHELL", "curl -f -u admin:admin-secret -s http://localhost:8085/subjects > /dev/null"]
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8085'"]
       interval: 5s
       timeout: 5s
       retries: 3

--- a/src/test/kotlin/io/specmatic/testcontainers/UnhealthyContainerHealthcheckLogger.kt
+++ b/src/test/kotlin/io/specmatic/testcontainers/UnhealthyContainerHealthcheckLogger.kt
@@ -63,12 +63,13 @@ class UnhealthyContainerHealthcheckLogger(val dockerClient: DockerClient) : Invo
         try {
             return proceed()
         } catch (e: Throwable) {
-            logUnhealthyContainerHealthchecks().forEach(e::addSuppressed)
-            throw e
+            val messages = logUnhealthyContainerHealthchecks()
+            if (messages.isEmpty()) throw e
+            throw UnhealthyContainerException(messages.joinToString("\n\n"), e)
         }
     }
 
-    private fun logUnhealthyContainerHealthchecks(): List<Throwable> {
+    private fun logUnhealthyContainerHealthchecks(): List<String> {
         val unhealthy = dockerClient.listContainersCmd()
             .withShowAll(true)
             .withFilter("health", listOf("unhealthy"))
@@ -80,11 +81,11 @@ class UnhealthyContainerHealthcheckLogger(val dockerClient: DockerClient) : Invo
                 .joinToString("\n") { "[exit=${it.exitCodeLong}] ${it.output?.trim()}" }
             val message = "Healthcheck output for unhealthy container '$name':\n$healthLog"
             logger.error(message)
-            UnhealthyContainerException(message)
+            message
         }
     }
 
-    private class UnhealthyContainerException(message: String) : Exception(message) {
+    private class UnhealthyContainerException(message: String, cause: Throwable) : Exception(message, cause) {
         override fun fillInStackTrace(): Throwable = this
     }
 }

--- a/src/test/kotlin/io/specmatic/testcontainers/UnhealthyContainerHealthcheckLogger.kt
+++ b/src/test/kotlin/io/specmatic/testcontainers/UnhealthyContainerHealthcheckLogger.kt
@@ -63,9 +63,9 @@ class UnhealthyContainerHealthcheckLogger(val dockerClient: DockerClient) : Invo
         try {
             return proceed()
         } catch (e: Throwable) {
-            val messages = logUnhealthyContainerHealthchecks()
-            if (messages.isEmpty()) throw e
-            throw UnhealthyContainerException(messages.joinToString("\n\n"), e)
+            val unhealthyContainerLogs = logUnhealthyContainerHealthchecks()
+            if (unhealthyContainerLogs.isEmpty()) throw e
+            throw UnhealthyContainerException(unhealthyContainerLogs.joinToString("\n\n"), e)
         }
     }
 


### PR DESCRIPTION
## Background

CI for `ContractTestUsingTestContainer` was failing with only a generic `ContainerLaunchException` / `compose up -d exited abnormally`, hiding the real cause: `confluentinc/cp-schema-registry:latest` no longer ships `curl`, so the schema-registry healthcheck exits 127 (`curl: command not found`), the container is marked unhealthy, and the testcontainers stack fails via `depends_on: service_healthy`.

PR #102 added `UnhealthyContainerHealthcheckLogger` to surface such causes, but they still never reached the test summary.

## Deliberate two-step approach

To prove the diagnostics work before fixing the bug, this PR is two commits:

1. **Diagnostics only** (`Surface testcontainers root cause...`) — CI **expected to fail**, but now reports the real cause in the FAILED summary.
2. **The actual fix** (`Fix schema-registry healthcheck...`) — CI should go green.

## What the diagnostics commit fixes

`UnhealthyContainerHealthcheckLogger` attached the healthcheck output as a **suppressed** exception. It turns out Gradle does **not** serialize suppressed exceptions across the test-worker boundary, so `exceptionFormat` could never render them — only the cause chain survives. Fix:

- Attach the healthcheck output as the exception **cause** instead of suppressed.
- Set `testLogging.exceptionFormat = 'full'` so the cause chain is printed.

Verified on CI run `28364571880` (commit `e647c38`, diagnostics only). The FAILED summary now leads with:

```
ContractTestUsingTestContainer > initializationError FAILED
io.specmatic.testcontainers.UnhealthyContainerHealthcheckLogger$UnhealthyContainerException: Healthcheck output for unhealthy container 'schema-registry':
[exit=127] /bin/sh: line 1: curl: command not found
...
Caused by: org.testcontainers.containers.ContainerLaunchException: Local Docker Compose exited abnormally ... at ContractTestUsingTestContainer.kt:52
```

## The fix

Replace the curl-based schema-registry healthcheck with the `bash` `/dev/tcp` TCP check the other cp services (zookeeper, broker) already use — no external tooling required. Verified locally that the container reaches `healthy`.
